### PR TITLE
Update main.c

### DIFF
--- a/src/brainslug-wii-vanilla/modules/rmc-local-net/main.c
+++ b/src/brainslug-wii-vanilla/modules/rmc-local-net/main.c
@@ -78,9 +78,9 @@ uint32_t array_yay_woo[] = {
 static void _start_patches(void) {
 
 	// fix for le-code distributions
-	if(((uint32_t *)&_start)[0x0] == 0x7ea802a6){
-		((uint32_t *)0x80000034)[0x0] = ((uint32_t *)0x80000034)[0x0] + 8;
-		((uint32_t *)0x80000034)[0x1] = ((uint32_t *)0x80000034)[0x1] + 8;
+	if(*(uint32_t *)_start == 0x7ea802a6){
+		*(uint32_t *)0x80000034 = *(uint32_t *)0x80000034 + 8;
+		*(uint32_t *)0x80000038 = *(uint32_t *)0x80000038 + 8;
 	}
 	
 	// force us to know ourselves

--- a/src/brainslug-wii-vanilla/modules/rmc-local-net/main.c
+++ b/src/brainslug-wii-vanilla/modules/rmc-local-net/main.c
@@ -76,16 +76,27 @@ uint32_t array_yay_woo[] = {
 #endif
 
 static void _start_patches(void) {
+
+	// fix for le-code distributions
+	if(((uint32_t *)&_start)[0x0] == 0x7ea802a6){
+		((uint32_t *)0x80000034)[0x0] = ((uint32_t *)0x80000034)[0x0] + 8;
+		((uint32_t *)0x80000034)[0x1] = ((uint32_t *)0x80000034)[0x1] + 8;
+	}
+	
 	// force us to know ourselves
 	DWC_ConnectToGameServerAsync2[0x3B] = 0x48000100;
 	DWC_ConnectToGameServerAsync2[0x7E] = 0x38000001;
+	
 	// work out where dwc_gamedata is
 	dwc_gamedata_offset = ((int16_t *)&dwc_process_status_record)[0xb];
+	
 	// stop the error condition preventing all online processing.
 	// TODO: this is actually patching the method starting 800ccc68 so this may not port.
 	((uint32_t *)&dwc_unknown_800ccc38)[0xF] = 0x60000000;
+	
 	// prevent error 5 when sending packets
 	dwc_unknown_800d577c[0x203] = 0x48000014;
+	
 	// disconnect gracefully on state machine lockup in joins
 	void *menu_data = get_port_address(9);
 	((uint32_t *)&dwc_think)[0x44] = 0x3c600000 + RELOC_HA(menu_data);

--- a/src/brainslug-wii-vanilla/modules/rmc-local-net/main.c
+++ b/src/brainslug-wii-vanilla/modules/rmc-local-net/main.c
@@ -78,9 +78,13 @@ uint32_t array_yay_woo[] = {
 static void _start_patches(void) {
 
 	// fix for le-code distributions
+	// check whether the first instruction of _start is the instruction mflr r21,
+	// and if so, correct the Arena High the Start of FST and the maximum FST size.
+	// very helpful reference for this topic https://wiibrew.org/wiki/Memory_map
 	if(*(uint32_t *)_start == 0x7ea802a6){
-		*(uint32_t *)0x80000034 = *(uint32_t *)0x80000034 + 8;
-		*(uint32_t *)0x80000038 = *(uint32_t *)0x80000038 + 8;
+		*(uint32_t *)0x80000034 = *(uint32_t *)0x80000034 + 8;	/* Arena High */
+		*(uint32_t *)0x80000038 = *(uint32_t *)0x80000038 + 8;	/* Start of FST */
+		*(uint32_t *)0x8000003c = *(uint32_t *)0x8000003c - 8;	/* Maximum FST Size */
 	}
 	
 	// force us to know ourselves

--- a/src/brainslug-wii-vanilla/modules/rmc-local-net/port_addresses.c
+++ b/src/brainslug-wii-vanilla/modules/rmc-local-net/port_addresses.c
@@ -1,24 +1,24 @@
 #include "port_addresses.h"
 
-/* E, J, P */
-static const uint32_t portAddresses[][3] = {
-	{ 0x8066B8D4, 0x806726A4, 0x80673038 }, /* login error branch */
-	{ 0x8065acc0, 0x80662c84, 0x80663618 }, /* mkw_get_fc_for_current_license */
-	{ 0x805c4f88, 0x805d1980, 0x805d20a4 }, /* mkw_load_friends_list_from_save */
-	{ 0x805c5098, 0x805d1a90, 0x805d21b4 }, /* mkw_copy_friends_list_to_save */
-	{ 0x80660f28, 0x80662678, 0x8066300c }, /* mkw_form_user_record */
-	{ 0x809bd938, 0x809c1170, 0x809c2110 }, /* friend tracking structure */
-	{ 0x80615148, 0x80646FC4, 0x80647958 }, /* where to go on connect success */
-	{ 0x8061a300, 0x8064cc80, 0x8064D614 }, /* what to do when pressing B at friend roster (not a method start) */
-	{ 0x8061a204, 0x8064cb84, 0x8064D518 }, /* what to do when pressing A on B at the friend roster (not a method start) */
-	{ 0x809BD508, 0x809C0E98, 0x809C1E38 }, /* menu_data */
-	{ 0x8066FCE0, 0x80676ab0, 0x80677444 }, /* stop ghosts sending */
-	{ 0x8065307c, 0x80656b70, 0x80657504 }, /* mkw_net_main_thread */
-	{ 0x805c97f0, 0x805d61e8, 0x805D690C }, /* Remove friend button pressed */
-	{ 0x805ddcd0, 0x80601d24, 0x806025B0 }, /* Render Popup */
-	{ 0x805c11e0, 0x805cd5dc, 0x805cdd00 }, /* BMG_Print */
-	{ 0x80831bcc, 0x8085084c, 0x808511e0 }, /* On Mario Kart Channel pressed (not a method start) */
-	{ 0x80839a2c, 0x8085ab28, 0x8085b4bc }, /* On Check Rankings pressed (not a method start) */
+/* E, J, P, K */
+static const uint32_t portAddresses[][4] = {
+	{ 0x8066B8D4, 0x806726A4, 0x80673038, 0x80661390 }, /* login error branch */															/*0*/
+	{ 0x8065acc0, 0x80662c84, 0x80663618, 0x80651930 }, /* mkw_get_fc_for_current_license */												/*1*/
+	{ 0x805c4f88, 0x805d1980, 0x805d20a4, 0x805c0240 }, /* mkw_load_friends_list_from_save */												/*2*/
+	{ 0x805c5098, 0x805d1a90, 0x805d21b4, 0x805c0350 }, /* mkw_copy_friends_list_to_save */													/*3*/
+	{ 0x80660f28, 0x80662678, 0x8066300c, 0x80651324 }, /* mkw_form_user_record */															/*4*/
+	{ 0x809bd938, 0x809c1170, 0x809c2110, 0x809b0750 }, /* friend tracking structure */														/*5*/
+	{ 0x80615148, 0x80646FC4, 0x80647958, 0x80635c70 }, /* where to go on connect success */												/*6*/
+	{ 0x8061a300, 0x8064cc80, 0x8064D614, 0x8063b92c }, /* what to do when pressing B at friend roster (not a method start) */				/*7*/
+	{ 0x8061a204, 0x8064cb84, 0x8064D518, 0x8063b830 }, /* what to do when pressing A on B at the friend roster (not a method start) */		/*8*/
+	{ 0x809BD508, 0x809C0E98, 0x809C1E38, 0x809B0478 }, /* menu_data */																		/*9*/
+	{ 0x8066FCE0, 0x80676ab0, 0x80677444, 0x806657ec }, /* stop ghosts sending */															/*10*/
+	{ 0x8065307c, 0x80656b70, 0x80657504, 0x8064581c }, /* mkw_net_main_thread */															/*11*/
+	{ 0x805c97f0, 0x805d61e8, 0x805D690C, 0x805c4aa8 }, /* Remove friend button pressed */													/*12*/
+	{ 0x805ddcd0, 0x80601d24, 0x806025B0, 0x805f09d0 }, /* Render Popup */																	/*13*/
+	{ 0x805c11e0, 0x805cd5dc, 0x805cdd00, 0x805bbcc0 }, /* BMG_Print */																		/*14*/
+	{ 0x80831bcc, 0x8085084c, 0x808511e0, 0x8083f5a0 }, /* On Mario Kart Channel pressed (not a method start) */							/*15*/
+	{ 0x80839a2c, 0x8085ab28, 0x8085b4bc, 0x8084987c }, /* On Check Rankings pressed (not a method start) */								/*16*/
 };
 
 void *get_port_address(int index) {
@@ -27,6 +27,7 @@ void *get_port_address(int index) {
 		game_id == 'E' ? 0 :
 		game_id == 'J' ? 1 :
 		game_id == 'P' ? 2 :
+		game_id == 'K' ? 3 :
 		/* deliberate crash! */
 		*(volatile int *)0;
 	return (void *)portAddresses[index][index2];


### PR DESCRIPTION
this fix should work on pre-composed LE-CODE distributions. only testet on Wiimms Mario Kart Fun 2023-09(RMCP51) and Wiimms Mario Kart Fun 2022-11(RMCP49) .

you don't need KamekLoader or emvolution because this fixes the problem with pre modified main.dol files so you can use pre-composed iso or wbfs images.